### PR TITLE
Smoothing at 1AM BOIIIII

### DIFF
--- a/EFI/OC/config.plist
+++ b/EFI/OC/config.plist
@@ -604,7 +604,7 @@
 			<key>CustomKernel</key>
 			<false/>
 			<key>FuzzyMatch</key>
-			<true/>
+			<false/>
 			<key>KernelArch</key>
 			<string>x86_64</string>
 			<key>KernelCache</key>
@@ -624,7 +624,7 @@
 			<key>HideAuxiliary</key>
 			<true/>
 			<key>LauncherOption</key>
-			<string>Disabled</string>
+			<string>Full</string>
 			<key>LauncherPath</key>
 			<string>Default</string>
 			<key>PickerAttributes</key>


### PR DESCRIPTION
- `Kernel/Scheme/FuzzyMatch`:

```
On macOS 10.6 and earlier, kernelcache filename has a checksum, which essentially is adler32 from SMBIOS
product name and EfiBoot device path. On certain firmware, the EfiBoot device path differs between UEFI and
macOS due to ACPI or hardware specifics, rendering kernelcache checksum as always different.
This setting allows matching the latest kernelcache with a suitable architecture when the kernelcache without
suffix is unavailable, improving macOS 10.6 boot performance on several platforms.
```
- `UEFI/AppleInput/GraphicsInputMirroring`

I don't know if I need it or not since I'm not using graphical application through OpenCore such as Winblows Bitlocker or whatever. Considered that I'm also using chain-loading via systemd-boot I don't think it should be left enabled but I need more research on it

That's all for now